### PR TITLE
feat: 도시 카드 좋아요/싫어요 버튼 레이아웃 개선

### DIFF
--- a/components/home/CityCard.tsx
+++ b/components/home/CityCard.tsx
@@ -28,33 +28,11 @@ export default function CityCard({ city }: CityCardProps) {
 
   return (
     <Link href={`/cities/${city.id}`}>
-      <div className="bg-white border border-gray-200 rounded-lg hover:shadow-lg hover:border-primary-300 transition-all duration-300 overflow-hidden cursor-pointer group">
+      <div className="bg-white border border-gray-200 rounded-lg hover:shadow-lg hover:border-primary-300 transition-all duration-300 overflow-hidden cursor-pointer group flex flex-col">
         {/* Header with emoji and city info */}
         <div className="p-6 border-b border-gray-100 bg-gradient-to-r from-primary-50 to-transparent">
           <div className="flex items-start justify-between mb-3">
             <div className="text-4xl">{city.emoji}</div>
-            <div className="flex gap-2">
-              <button
-                onClick={handleFavoriteClick}
-                className="p-1.5 hover:bg-white rounded-lg transition-colors"
-                title={isFavorite ? '좋아요 취소' : '좋아요'}
-              >
-                <Heart
-                  size={20}
-                  className={isFavorite ? 'fill-red-500 text-red-500' : 'text-gray-400 hover:text-red-500'}
-                />
-              </button>
-              <button
-                onClick={handleBookmarkClick}
-                className="p-1.5 hover:bg-white rounded-lg transition-colors"
-                title={isBookmarked ? '북마크 취소' : '북마크'}
-              >
-                <Bookmark
-                  size={20}
-                  className={isBookmarked ? 'fill-blue-500 text-blue-500' : 'text-gray-400 hover:text-blue-500'}
-                />
-              </button>
-            </div>
           </div>
           <h3 className="text-lg font-bold text-gray-900">{city.name}</h3>
           <p className="text-sm text-gray-600">{city.province}</p>
@@ -86,6 +64,35 @@ export default function CityCard({ city }: CityCardProps) {
         <div className="px-6 py-4 border-b border-gray-100 flex items-center gap-2 text-sm text-gray-600">
           <MessageCircle size={14} />
           <span>{city.reviews_count}개 리뷰</span>
+        </div>
+
+        {/* Likes and Dislikes Section */}
+        <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+          {/* Likes - Left */}
+          <button
+            onClick={handleFavoriteClick}
+            className="flex items-center gap-2 p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            title={isFavorite ? '좋아요 취소' : '좋아요'}
+          >
+            <Heart
+              size={18}
+              className={isFavorite ? 'fill-red-500 text-red-500' : 'text-gray-400 hover:text-red-500'}
+            />
+            <span className="text-sm font-semibold text-gray-700">{city.likes_count || 0}</span>
+          </button>
+
+          {/* Dislikes - Right */}
+          <button
+            onClick={handleBookmarkClick}
+            className="flex items-center gap-2 p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            title={isBookmarked ? '북마크 취소' : '북마크'}
+          >
+            <span className="text-sm font-semibold text-gray-700">{city.dislikes_count || 0}</span>
+            <Bookmark
+              size={18}
+              className={isBookmarked ? 'fill-blue-500 text-blue-500' : 'text-gray-400 hover:text-blue-500'}
+            />
+          </button>
         </div>
 
         {/* Action Button */}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -14,6 +14,8 @@ export const cities: City[] = [
     work_score: 9.5,
     quality_score: 8.3,
     reviews_count: 245,
+    likes_count: 342,
+    dislikes_count: 28,
     description: '한국의 중심, 가장 많은 노마드가 활동하는 도시',
     gallery_images: [
       'https://images.unsplash.com/photo-1566073771259-6a8506099945?w=500',
@@ -47,6 +49,8 @@ export const cities: City[] = [
     work_score: 7.8,
     quality_score: 8.9,
     reviews_count: 156,
+    likes_count: 287,
+    dislikes_count: 19,
     description: '바다와 산이 어우러진 평화로운 도시',
     gallery_images: [
       'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=500',
@@ -80,6 +84,8 @@ export const cities: City[] = [
     work_score: 7.5,
     quality_score: 8.7,
     reviews_count: 128,
+    likes_count: 256,
+    dislikes_count: 12,
     description: '문화와 전통이 살아있는 매력적인 도시',
     gallery_images: [
       'https://images.unsplash.com/photo-1583697162222-aebb256cb406?w=500',
@@ -113,6 +119,8 @@ export const cities: City[] = [
     work_score: 8.2,
     quality_score: 7.8,
     reviews_count: 184,
+    likes_count: 298,
+    dislikes_count: 24,
     description: '대한민국 제2의 도시, 활기찬 분위기',
     gallery_images: [
       'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=500',
@@ -146,6 +154,8 @@ export const cities: City[] = [
     work_score: 7.2,
     quality_score: 7.6,
     reviews_count: 92,
+    likes_count: 178,
+    dislikes_count: 15,
     description: '저렴한 생활비와 친절한 지역민',
     gallery_images: [
       'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=500',
@@ -179,6 +189,8 @@ export const cities: City[] = [
     work_score: 8.0,
     quality_score: 9.1,
     reviews_count: 167,
+    likes_count: 312,
+    dislikes_count: 18,
     description: '아름다운 자연과 함께하는 노마드 생활',
     gallery_images: [
       'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=500',
@@ -212,6 +224,8 @@ export const cities: City[] = [
     work_score: 7.0,
     quality_score: 8.2,
     reviews_count: 68,
+    likes_count: 142,
+    dislikes_count: 9,
     description: '예술의 도시, 창의적인 분위기',
     gallery_images: [
       'https://images.unsplash.com/photo-1460661419201-fd4cecdf8a8b?w=500',
@@ -245,6 +259,8 @@ export const cities: City[] = [
     work_score: 7.3,
     quality_score: 7.9,
     reviews_count: 75,
+    likes_count: 156,
+    dislikes_count: 11,
     description: '과학과 기술의 도시, 미래 지향적',
     gallery_images: [
       'https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=500',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,8 @@ export interface City {
   work_score: number
   quality_score: number
   reviews_count: number
+  likes_count?: number
+  dislikes_count?: number
   description?: string
   image_url?: string
   gallery_images?: string[]


### PR DESCRIPTION
## 요약

도시 카드의 좋아요(Heart) 및 싫어요(Bookmark) 버튼 레이아웃을 개선했습니다.
- 좋아요 버튼을 카드 왼쪽에 배치
- 싫어요 버튼을 카드 오른쪽에 배치  
- 각 버튼 옆에 카운트 숫자를 표시 (`[아이콘][숫자]` 형식)

## 변경사항

### 데이터 구조 (lib/types.ts)
- City 인터페이스에 `likes_count?`, `dislikes_count?` 필드 추가

### Mock 데이터 (lib/data.ts)
- 8개 도시의 좋아요/싫어요 카운트 추가
  - 서울: 342 likes, 28 dislikes
  - 강릉: 287 likes, 19 dislikes
  - 전주: 256 likes, 12 dislikes
  - 부산: 298 likes, 24 dislikes
  - 대구: 178 likes, 15 dislikes
  - 제주: 312 likes, 18 dislikes
  - 광주: 142 likes, 9 dislikes
  - 대전: 156 likes, 11 dislikes

### 컴포넌트 리팩토링 (components/home/CityCard.tsx)
- 헤더에서 좋아요/싫어요 버튼 제거
- 새로운 액션 섹션 추가 (리뷰와 상세보기 버튼 사이)
- Flexbox로 좌우 정렬 구현
- 각 버튼 옆에 카운트 숫자 표시
- Tailwind CSS 호버 효과 및 스타일 적용

## 테스트

- ✅ 빌드 성공 (TypeScript, ESLint 검증)
- ✅ 기존 onClick 핸들러 기능 유지
- ✅ 반응형 레이아웃 유지
- ✅ 모바일/태블릿/데스크톱 호환성 확인

## 체크리스트

- [x] City 타입 필드 추가
- [x] Mock 데이터 업데이트
- [x] 컴포넌트 리팩토링
- [x] 좌우 정렬 레이아웃 구현
- [x] 카운트 숫자 표시
- [x] 스타일링 완료
- [x] 빌드 검증
- [x] git 커밋